### PR TITLE
Fix Google OAuth redirect_uri_mismatch error

### DIFF
--- a/WirdBackend/WirdBackend/settings/settings.py
+++ b/WirdBackend/WirdBackend/settings/settings.py
@@ -193,7 +193,8 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTH_KIT = {
     'SOCIAL_LOGIN_AUTH_TYPE': 'code',  # Recommended: 'code' for security, or 'token'
     "USER_SERIALIZER": "core.serializers.PersonSerializer",
-    "USE_AUTH_COOKIE": False
+    "USE_AUTH_COOKIE": False,
+    "SOCIAL_LOGIN_CALLBACK_URL_GENERATOR": "core.util_methods.get_social_callback_url",
 }
 
 SOCIALACCOUNT_PROVIDERS = {

--- a/WirdBackend/core/util_methods.py
+++ b/WirdBackend/core/util_methods.py
@@ -54,6 +54,14 @@ def is_person_role_in_contest(request, expected_roles):
     return bool(current_contest_role in expected_roles)
 
 
+def get_social_callback_url(request, view, social_app):
+    redirect_uri = request.data.get("redirect_uri")
+    if redirect_uri:
+        return redirect_uri
+    from auth_kit.social.utils import get_social_login_callback_url
+    return get_social_login_callback_url(request, view, social_app)
+
+
 def get_contest_and_request_related_start_and_end_date(request, contest):
     contest_start_date = contest.start_date
     contest_end_date = contest.end_date


### PR DESCRIPTION
## Why
The frontend uses `@react-oauth/google` with popup-based auth-code flow, which registers `redirect_uri=postmessage` with Google. When the backend exchanges the code, `drf-auth-kit` constructs a server-side redirect URI (`https://api-dev.wird.app/auth/social/google/`), causing Google to reject the request with `redirect_uri_mismatch`.

## How
Added a custom `SOCIAL_LOGIN_CALLBACK_URL_GENERATOR` that reads `redirect_uri` from `request.data` (sent by the frontend as `"postmessage"`), falling back to the default behavior for non-popup flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)